### PR TITLE
Fix deselectAllLayers issue in Sketch 45 by using Sketch API

### DIFF
--- a/Artboard.sketchplugin/Contents/Sketch/Next Artboard.js
+++ b/Artboard.sketchplugin/Contents/Sketch/Next Artboard.js
@@ -40,7 +40,7 @@ var nextArtboard = function(context) {
   var currentArtboard = [artboards objectAtIndex: currentArtboardIndex];
   var currentArtboardRect = [currentArtboard absoluteRect];
 
-  var nextArtboardIndex = (currentArtboardIndex + 1) % [artboards count];
+  var nextArtboardIndex = (currentArtboardIndex + [artboards count] - 1) % [artboards count];
   var nextArtboard;
 
   if (currentArtboard == [page currentArtboard] || [page currentArtboard] == null) {

--- a/Artboard.sketchplugin/Contents/Sketch/Next Artboard.js
+++ b/Artboard.sketchplugin/Contents/Sketch/Next Artboard.js
@@ -54,7 +54,7 @@ var nextArtboard = function(context) {
 
   var nextArtboardRect = [nextArtboard absoluteRect];
 
-  [[doc currentPage] deselectAllLayers]
+  context.api().selectedDocument.selectedPage.selectedLayers.clear();
   [nextArtboard select:true byExpandingSelection:true]
 
   var newX = [nextArtboardRect x];

--- a/Artboard.sketchplugin/Contents/Sketch/Previous Artboard.js
+++ b/Artboard.sketchplugin/Contents/Sketch/Previous Artboard.js
@@ -54,7 +54,7 @@ var previousArtboard = function(context) {
 
   var prevArtboardRect = [prevArtboard absoluteRect];
 
-  [[doc currentPage] deselectAllLayers]
+  context.api().selectedDocument.selectedPage.selectedLayers.clear();
   [prevArtboard select:true byExpandingSelection:true]
 
   var newX = [prevArtboardRect x];

--- a/Artboard.sketchplugin/Contents/Sketch/Previous Artboard.js
+++ b/Artboard.sketchplugin/Contents/Sketch/Previous Artboard.js
@@ -40,7 +40,7 @@ var previousArtboard = function(context) {
   var currentArtboard = [artboards objectAtIndex: currentArtboardIndex];
   var currentArtboardRect = [currentArtboard absoluteRect];
 
-  var prevArtboardIndex = (currentArtboardIndex + [artboards count] - 1) % [artboards count];
+  var prevArtboardIndex = (currentArtboardIndex + 1) % [artboards count];
   var prevArtboard;
 
   if (currentArtboard == [page currentArtboard] || [page currentArtboard] == null) {


### PR DESCRIPTION
Thanks Ken for the great plugin.  This PR has two commits:

1. A fix for deselecting all layers that prevented the next/previous artboard actions from working in Sketch 45. I have tested this in Sketch 45, though not in previous versions.

2. Switching the logic of next/previous artboard so that it matches that of next/previous page (namely that the previous artboard is above the current selected one and the next artboard is below it).  This is much more intuitive to me, though perhaps it is not your intended design.